### PR TITLE
fix: fix notification window causes the main window to lose focus.

### DIFF
--- a/.changes/fix-win7-focus.md
+++ b/.changes/fix-win7-focus.md
@@ -1,0 +1,6 @@
+---
+"win7-notifications": "patch"
+---
+
+fix: The message notification window causes the main window to lose focus.
+

--- a/.changes/fix-win7-focus.md
+++ b/.changes/fix-win7-focus.md
@@ -2,5 +2,5 @@
 "win7-notifications": "patch"
 ---
 
-fix: The message notification window causes the main window to lose focus.
+Fix notification window causes the main window to lose focus.
 

--- a/src/notification.rs
+++ b/src/notification.rs
@@ -182,10 +182,10 @@ impl Notification {
                 };
 
                 let hwnd = CreateWindowExW(
-                    WS_EX_TOPMOST,
+                    WS_EX_TOPMOST | WS_EX_NOACTIVATE,
                     class_name,
                     w!("win7-notifications-window"),
-                    WS_SYSMENU | WS_CAPTION | WS_VISIBLE,
+                    WS_POPUP | WS_BORDER,
                     right - NW - 15,
                     bottom - NH - 15,
                     NW,
@@ -232,7 +232,7 @@ impl Notification {
                 }
 
                 util::skip_taskbar(hwnd);
-                ShowWindow(hwnd, SW_SHOW);
+                ShowWindow(hwnd, SW_SHOWNA);
                 if !self.silent {
                     // Passing an invalid path to `PlaySoundW` will make windows play default sound.
                     // https://docs.microsoft.com/en-us/previous-versions/dd743680(v=vs.85)#remarks


### PR DESCRIPTION
This problem should be caused by the style parameters of `CreateWindowExW` and `ShowWindow`. The solution is also provided here: https://www.codeproject.com/Questions/751002/Show-Window-without-activating

After modification, it can work normally on my computer.