### PR TITLE
fix: multi-message notification causing application to become unresponsive

### DIFF
--- a/.changes/fix-unresponsive
+++ b/.changes/fix-unresponsive
@@ -1,0 +1,5 @@
+---
+"win7-notifications": "patch"
+---
+
+Fix multi-message notification causing application to become unresponsive


### PR DESCRIPTION
#68 When there is a new message notification, the historical message will be automatically closed.